### PR TITLE
#3 Adds mock for token

### DIFF
--- a/src/main/java/se/sundsvall/teamssender/configuration/MockTokenServiceConfiguration.java
+++ b/src/main/java/se/sundsvall/teamssender/configuration/MockTokenServiceConfiguration.java
@@ -1,0 +1,45 @@
+package se.sundsvall.teamssender.configuration;
+
+import com.azure.core.credential.TokenCredential;
+import com.microsoft.graph.serviceclient.GraphServiceClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import se.sundsvall.teamssender.auth.integration.StaticTokenCredential;
+import se.sundsvall.teamssender.auth.repository.ITokenCacheRepository;
+import se.sundsvall.teamssender.auth.service.TokenService;
+
+@Configuration
+@Profile("mock")
+public class MockTokenServiceConfiguration {
+
+	@Value("${graph.base-url}")
+	private String graphBaseUrl;
+
+	@Bean
+	@Primary
+	public TokenService mockTokenService(AzureConfig azureConfig, ITokenCacheRepository tokenCacheRepository) {
+
+		return new TokenService(azureConfig, tokenCacheRepository) {
+
+			@Override
+			public String getAccessTokenForUser(String municipalityId) {
+				return "mock-access-token";
+			}
+
+			@Override
+			public GraphServiceClient initializeGraphServiceClient(String municipalityId) {
+				TokenCredential credential = new StaticTokenCredential("mock-access-token");
+				GraphServiceClient client = new GraphServiceClient(credential);
+
+				try {
+					client.getRequestAdapter().setBaseUrl(graphBaseUrl);
+				} catch (Exception ignored) {}
+
+				return client;
+			}
+		};
+	}
+}


### PR DESCRIPTION
Adds functionality to mock-token for mocked teamssender message requests. Files for mocking with docker and wiremock can be found in https://github.com/Public-Service-as-a-Service/lia-projekt-2